### PR TITLE
Fix a deprecation warning in ActiveRecord 7

### DIFF
--- a/lib/light_record.rb
+++ b/lib/light_record.rb
@@ -222,7 +222,11 @@ module LightRecord
 
       options = {
         stream: false, symbolize_keys: true, cache_rows: false, as: :hash,
-        database_timezone: ActiveRecord::Base.default_timezone
+        database_timezone: (
+          ActiveRecord.respond_to?(:default_timezone) ?
+          ActiveRecord.default_timezone :
+          ActiveRecord::Base.default_timezone
+        )
       }.merge(options)
 
       result = _light_record_execute_query(connection, sql, options.except(:set_const))
@@ -253,7 +257,11 @@ module LightRecord
 
       options = {
         stream: true, symbolize_keys: true, cache_rows: false, as: :hash,
-        database_timezone: ActiveRecord::Base.default_timezone
+        database_timezone: (
+          ActiveRecord.respond_to?(:default_timezone) ?
+          ActiveRecord.default_timezone :
+          ActiveRecord::Base.default_timezone
+        )
       }.merge(options)
 
       result = _light_record_execute_query(conn, sql, options.except(:set_const))


### PR DESCRIPTION
Fixes this warning when using light_record with Rails 7: 

    DEPRECATION WARNING: ActiveRecord::Base.default_timezone is deprecated and will be removed in Rails 7.1.
    Use `ActiveRecord.default_timezone` instead.`

* `ActiveRecord::Base.default_timezone` will be gone in Rails 7.1; replace with `ActiveRecord.default_timezone`
* Used respont_to instead of check for specific rails version for better compatibility
